### PR TITLE
fix #33 election_mode table added

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,14 @@ polish_db :
 	sqlite-utils convert nlrb.db filing case_number 'value.split("-")[1]' --output case_type
 	sqlite-utils convert nlrb.db filing case_number '"https://www.nlrb.gov/case/" + value' --output url
 	sqlite-utils create-index nlrb.db filing --if-not-exists -- case_type -created_at -date_filed
+	sqlite-utils convert nlrb.db election_mode date_filed 'r.parsedate(value)'
+	sqlite-utils convert nlrb.db election_mode date_closed 'r.parsedate(value)'
+	sqlite-utils convert nlrb.db election_mode date_ballot_mailed 'r.parsedate(value)'
+	sqlite-utils convert nlrb.db election_mode date_ballot_counted 'r.parsedate(value)'
+	sqlite-utils convert nlrb.db election_mode date_election_scheduled 'r.parsedate(value)'
+	sqlite-utils convert nlrb.db election_mode date_tally_scheduled 'r.parsedate(value)'
+	sqlite-utils convert nlrb.db election_mode date_tallied 'r.parsedate(value)'
+	#Can a unique election_id be assigned to each row in the election_mode table? Query in scripts/election_mode.sql is my best but failed attempt to do so.
 	sqlite-utils vacuum nlrb.db
 
 tally.csv :
@@ -66,6 +74,7 @@ filing.csv :
 	tr -d '\000' < temp_$@ > $@
 	rm temp_$@
 
-nlrb.db : 
+nlrb.db :
 	(wget -O /tmp/$$.zip $(DB_URL) && unzip /tmp/$$.zip) || sqlite3 $@ < scripts/initialize.sql
+	python3 scripts/election_mode.py
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 https://github.com/labordata/nlrb-cases/archive/refs/heads/main.zip
 tqdm
 sqlite-utils
+pandas
+openpyxl
+sqlite3

--- a/scripts/election_mode.py
+++ b/scripts/election_mode.py
@@ -1,0 +1,78 @@
+import pandas as pd
+import sqlite3
+
+
+con = sqlite3.connect('nlrb.db')
+
+cur = con.cursor()
+
+cur.execute(
+  """
+  SELECT name FROM sqlite_master WHERE type='table' AND name='election_mode';
+  """
+)
+
+#if election_mode table is not in nlrb.db, create and populate it
+if cur.fetchone() is None:
+  election_mode_df = pd.read_excel(
+    'raw/NLRB-2022-000194_final-Election_results_with_election_mode_Jan_2017-Nov_2021.xlsx',
+    sheet_name = 'Sheet1',
+    header = 4
+  )
+
+  cur.execute(
+    """
+    CREATE TABLE IF NOT EXISTS election_mode (
+      case_number TEXT,
+      name TEXT, --identical to [filing.name] after trim and max character limit
+      city TEXT, --identical to [filing.city] after trim
+      state TEXT, --identical to [filing.state]
+      status TEXT, --32 mismatches with [filings.status], which is presumably more recent
+      date_filed TEXT, --1 mismatch with [filing.date_filed]: case_number='14-RC-280405'
+      date_closed TEXT, --1 mismatch with [filing.date_closed]: case_number='13-RD-281948'
+      reason_closed TEXT, --1 mismatch with [filing.date_closed]: case_number in ('13-RD-281948', '21-RC-282430')
+      election_mode TEXT,
+      date_ballot_mailed TEXT,
+      date_ballot_counted TEXT,
+      date_election_scheduled TEXT,
+      date_tally_scheduled TEXT,
+      date_tallied TEXT,
+      tally_type TEXT, --need election_id to match with [election.tally_type]
+      ballot_type TEXT, --need election_id to match with [election.ballot_type]
+      unit_id TEXT, --identical to [voting_unit.unit_id]
+      ballots_impounded TEXT,
+      number_of_eligible_voters INTEGER, --253 mismatches, when summed by case_number, with [election.unit_size]
+      number_of_void_ballots INTEGER, --47 mismatches, when summed by case_number, with [election_result.void_ballots]
+      labor_organization_1_name TEXT,
+      votes_for_labor_organization_1 INTEGER,
+      labor_organization_2_name TEXT,
+      votes_for_labor_organization_2 INTEGER,
+      labor_organization_3_name TEXT,
+      votes_for_labor_organization_3 INTEGER,
+      votes_cast_against_labor_org INTEGER,
+      number_of_valid_votes_counted INTEGER, --250 mismatches, when summed by case_number, with [election_result.total_ballots_counted]; 905 mismatches with [tally.votes]
+      number_of_challenged_ballots INTEGER, --108 mismatches, when summed by case_number, with [election_result.challenged_ballots]
+      challenges_are_determinative TEXT, --34 mismatches, when summed by case_number, with [election_result.challenges_are_determinative]
+      runoff_required TEXT, --1 mismatch, when summed by case_number, with [election_result.runoff_required]: case_number = '32-RC-210194'
+      union_to_certify TEXT, --need election_id to match with [election_result.union_to_certify]
+      unit_involved_in_petition TEXT, --need election_id to match with [sought_unit.unit_sought]
+      bargaining_unit_determined TEXT,
+      FOREIGN KEY(case_number) REFERENCES filings(case_number)
+    );
+    """
+  )
+
+  #get column names from election_mode table
+  cur.execute('SELECT * FROM election_mode LIMIT 5')
+
+  col_names = [description[0] for description in cur.description]
+
+  election_mode_df.rename(columns = dict(zip(election_mode_df.columns, col_names))) \
+                  .to_sql('election_mode',
+                          con,
+                          if_exists = 'replace',
+                          index = False)
+
+con.commit()
+
+con.close()

--- a/scripts/election_mode.sql
+++ b/scripts/election_mode.sql
@@ -1,0 +1,13 @@
+--My failed attempt to assign a unique election_id to each row in election_mode table; case numbers like 06-RC-257937 make uniqueness hard
+SELECT c.election_id, a.*
+FROM election_mode a
+LEFT JOIN voting_unit b
+ON a.case_number = b.case_number
+AND a.unit_id  = b.unit_id
+LEFT JOIN election c
+ON b.voting_unit_id = c.voting_unit_id
+AND a.tally_type = c.tally_type
+AND a.tally_category = c. ballot_type
+INNER JOIN election_result d
+ON c.election_id = d.election_id
+AND CASE WHEN a.challenges_are_determinative = 'Y' THEN a.challenges_are_determinative = d.challenges_are_determinative ELSE 1 END

--- a/scripts/initialize.sql
+++ b/scripts/initialize.sql
@@ -18,9 +18,9 @@ CREATE TABLE filing (case_number text not null primary key,
 
 CREATE TABLE sought_unit(case_number text,
                          unit_sought text,
-			 created_at timestamp default CURRENT_TIMESTAMP, 
+			 created_at timestamp default CURRENT_TIMESTAMP,
 			 UNIQUE(case_number, unit_sought),
-			 FOREIGN KEY(case_number) REFERENCES filing(case_number)); 
+			 FOREIGN KEY(case_number) REFERENCES filing(case_number));
 
 
 CREATE TABLE docket (case_number text not null,
@@ -53,7 +53,7 @@ CREATE TABLE filing_group(root_case_number TEXT,
                         case_number TEXT NOT NULL PRIMARY KEY,
 		        created_at timestamp default CURRENT_TIMESTAMP,
                         updated_at timestamp default CURRENT_TIMESTAMP);
-			FOREIGN KEY(case_number) REFERENCES filing(case_number));			 
+			FOREIGN KEY(case_number) REFERENCES filing(case_number));
 
 CREATE TABLE voting_unit (voting_unit_id INTEGER PRIMARY KEY AUTOINCREMENT,
                           case_number text NOT NULL,
@@ -91,5 +91,42 @@ CREATE table tally(election_id int,
 		   created_at timestamp default CURRENT_TIMESTAMP,
 		   FOREIGN KEY(election_id) REFERENCES election(election_id));
 
+  CREATE TABLE election_mode (
+    case_number TEXT,
+    name TEXT, --identical to [filing.name] after trim and max character limit
+    city TEXT, --identical to [filing.city] after trim
+    state TEXT, --identical to [filing.state]
+    status TEXT, --32 mismatches with [filings.status], which is presumably more recent
+    date_filed TEXT, --1 mismatch with [filing.date_filed]: case_number='14-RC-280405'
+    date_closed TEXT, --1 mismatch with [filing.date_closed]: case_number='13-RD-281948'
+    reason_closed TEXT, --1 mismatch with [filing.date_closed]: case_number in ('13-RD-281948', '21-RC-282430')
+    election_mode TEXT,
+    date_ballot_mailed TEXT,
+    date_ballot_counted TEXT,
+    date_election_scheduled TEXT,
+    date_tally_scheduled TEXT,
+    date_tallied TEXT,
+    tally_type TEXT, --need election_id to match with [election.tally_type]
+    ballot_type TEXT, --need election_id to match with [election.ballot_type]
+    unit_id TEXT, --identical to [voting_unit.unit_id]
+    ballots_impounded TEXT,
+    number_of_eligible_voters INTEGER, --253 mismatches, when summed by case_number, with [election.unit_size]
+    number_of_void_ballots INTEGER, --47 mismatches, when summed by case_number, with [election_result.void_ballots]
+    labor_organization_1_name TEXT,
+    votes_for_labor_organization_1 INTEGER,
+    labor_organization_2_name TEXT,
+    votes_for_labor_organization_2 INTEGER,
+    labor_organization_3_name TEXT,
+    votes_for_labor_organization_3 INTEGER,
+    votes_cast_against_labor_org INTEGER,
+    number_of_valid_votes_counted INTEGER, --250 mismatches, when summed by case_number, with [election_result.total_ballots_counted]; 905 mismatches with [tally.votes]
+    number_of_challenged_ballots INTEGER, --108 mismatches, when summed by case_number, with [election_result.challenged_ballots]
+    challenges_are_determinative TEXT, --34 mismatches, when summed by case_number, with [election_result.challenges_are_determinative]
+    runoff_required TEXT, --1 mismatch, when summed by case_number, with [election_result.runoff_required]: case_number = '32-RC-210194'
+    union_to_certify TEXT, --need election_id to match with [election_result.union_to_certify]
+    unit_involved_in_petition TEXT, --need election_id to match with [sought_unit.unit_sought]
+    bargaining_unit_determined TEXT,
+    FOREIGN KEY(case_number) REFERENCES filings(case_number)
+  );
 
-		   
+


### PR DESCRIPTION
In the new create table statements in election_mode.py and initialize.sql, I commented next to columns that are in other tables and noted the mismatches. Some of these columns maybe could be dropped. In election_mode.sql, I tried but failed to construct an election_id column for the election_mode table. It might be possible.