### PR TITLE
Pin scrapy < 2.17 (stay on 2.16, guard the next bump)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,9 @@ sqlite-utils
 csvkit
 https://github.com/LuighiV/csvs-to-sqlite/archive/refs/heads/main.zip
 https://github.com/labordata/nlrb-scrapy/archive/refs/heads/main.zip
+# Pin scrapy: 2.16 stopped calling the spider's start_requests() method,
+# which silently broke the case scraper (0 items scraped) from 2026-05-20.
+# nlrb-scrapy now also defines start() for 2.16+ compatibility; this cap
+# guards against further unvetted scrapy releases breaking the nightly build.
+scrapy < 2.16
 pyOpenSSL >= 23.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,10 @@ sqlite-utils
 csvkit
 https://github.com/LuighiV/csvs-to-sqlite/archive/refs/heads/main.zip
 https://github.com/labordata/nlrb-scrapy/archive/refs/heads/main.zip
-# Pin scrapy: 2.16 stopped calling the spider's start_requests() method,
-# which silently broke the case scraper (0 items scraped) from 2026-05-20.
-# nlrb-scrapy now also defines start() for 2.16+ compatibility; this cap
-# guards against further unvetted scrapy releases breaking the nightly build.
-scrapy < 2.16
+# Pin scrapy: 2.16 dropped the call to the spider's deprecated
+# start_requests() method, which silently broke the case scraper (0 items
+# scraped) from 2026-05-20 until nlrb-scrapy added an async start(). Stay on
+# 2.16 but cap below the next minor so an unvetted scrapy release can't break
+# the nightly build the same way again.
+scrapy < 2.17
 pyOpenSSL >= 23.2.0


### PR DESCRIPTION
## Problem

The `Update Database` workflow reported **success every night while scraping 0 case pages from 2026-05-20**, so no new filings were added (the public site froze at May 19). Run durations dropped from ~45–55 min to ~5 min on that date.

## Root cause

The case spider (`labordata/nlrb-scrapy`) defined the deprecated `start_requests()` method. **scrapy 2.16.0 stopped calling it**, so the spider yielded zero requests → `Stored jl feed (0 items)` → `0 rows insert into filing`. The only diff between the last good run (2026-05-19, scrapy **2.15.2**) and the first broken run (2026-05-20, scrapy **2.16.0**) was this transitive upgrade — neither scrapy nor `nlrb-scrapy` was pinned.

## Fix

`nlrb-scrapy` now defines an async `start()` (PR labordata/nlrb-scrapy#1), so the spider works on **2.16**. This change keeps us on the tested 2.16 line and caps `scrapy < 2.17` so an unvetted future scrapy release can't silently break the nightly build the same way.

Merge labordata/nlrb-scrapy#1 first (or together), then re-run the `Update Database` workflow once to backfill ~4 weeks of missed filings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)