### PR TITLE
Add optional start_date input to build workflow for backfills

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,13 @@ on:
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+    inputs:
+      start_date:
+        description: >-
+          Discover new filings since this date (YYYY-MM-DD) for a one-off
+          backfill. Leave blank for the normal 14-day window.
+        required: false
+        default: ""
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -26,6 +33,12 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Set current date as env variable
         run: echo "BEGIN_NLRB_RUN=$(date +'%s')" >> $GITHUB_ENV
+      # Optional manual backfill: widen the new-filing discovery window.
+      # Only set NLRB_START_DATE when a date was supplied, otherwise the
+      # Makefile's default 14-day window applies.
+      - name: Set backfill start date
+        if: github.event.inputs.start_date != ''
+        run: echo "NLRB_START_DATE=${{ github.event.inputs.start_date }}" >> $GITHUB_ENV
       - uses: actions/checkout@v2
         
       - name: install requirements


### PR DESCRIPTION
## Why

The nightly only discovers **new** filings from NLRB's recent-filings report within the last **14 days** (`NLRB_START_DATE = 14 days ago`); the rest of the run just re-checks already-known open cases. So after an outage longer than two weeks, a normal run can't recover the missed filings — they're outside the window and not yet in the DB.

This is exactly the situation after the 2026-05-20 scrapy-2.16 break: new filings dated ~May 19–31 won't come back via an ordinary run.

## Change

Adds an optional `start_date` `workflow_dispatch` input. When set, a step writes it to `NLRB_START_DATE` for the run; when blank — every scheduled run and ordinary manual run — nothing is set and the Makefile's default 14-day window applies unchanged.

## Usage

After merge, from the Actions tab (or CLI) trigger a one-off backfill:

```
gh workflow run build.yml -R labordata/nlrb-data -f start_date=2026-05-15
```

That single run widens new-filing discovery back to May 15; the regular nightly takes over afterward. (`start_date=0` is also accepted by filings.py and means "last 365 days".)

🤖 Generated with [Claude Code](https://claude.com/claude-code)